### PR TITLE
サーヴァント用 Data Model を定義

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -31,6 +31,10 @@
         "Name": "Name",
         "Fame": "Fame",
         "Wish": "Wish"
+      },
+      "Servant": {
+        "TrueName": "True Name",
+        "Wish": "Wish"
       }
     },
     "SheetLabels": {
@@ -63,7 +67,8 @@
     "Actor": {
       "character": "Character",
       "npc": "NPC",
-      "mater": "Master"
+      "mater": "Master",
+      "servant": "Servant"
     },
     "Item": {
       "item": "Item",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -23,6 +23,10 @@
         "Name": "名前",
         "Fame": "家名",
         "Wish": "願い事"
+      },
+      "Servant": {
+        "TrueName": "真名",
+        "Wish": "願い事"
       }
     },
     "Template": {
@@ -38,7 +42,8 @@
     "Actor": {
       "character": "キャラクター",
       "npc": "NPC",
-      "master": "マスター"
+      "master": "マスター",
+      "servant": "サーヴァント"
     }
   }
 }

--- a/module/data/_module.mjs
+++ b/module/data/_module.mjs
@@ -3,6 +3,7 @@ export {default as HolyGrailWarTRPGActorBase} from "./base-actor.mjs";
 export {default as HolyGrailWarTRPGCharacter} from "./actor-character.mjs";
 export {default as HolyGrailWarTRPGNPC} from "./actor-npc.mjs";
 export {default as HolyGrailWarTRPGMaster} from "./actor-master.mjs";
+export {default as HolyGrailWarTRPGServant } from "./actor-servant.mjs";
 
 // Export Items
 export {default as HolyGrailWarTRPGItemBase} from "./base-item.mjs";

--- a/module/data/actor-servant.mjs
+++ b/module/data/actor-servant.mjs
@@ -1,0 +1,15 @@
+import HolyGrailWarTRPGActorBase from "./base-actor.mjs";
+
+export default class HolyGrailWarTRPGServant extends HolyGrailWarTRPGActorBase {
+
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    const schema = super.defineSchema();
+
+    schema.true_name = new fields.StringField({ required: true, blank: true });
+    schema.wish = new fields.StringField({ required: true, blank: true });
+
+    return schema;
+  }
+
+}

--- a/module/holy-grail-war-trpg.mjs
+++ b/module/holy-grail-war-trpg.mjs
@@ -44,7 +44,8 @@ Hooks.once('init', function () {
   CONFIG.Actor.dataModels = {
     character: models.HolyGrailWarTRPGCharacter,
     npc: models.HolyGrailWarTRPGNPC,
-    master: models.HolyGrailWarTRPGMaster
+    master: models.HolyGrailWarTRPGMaster,
+    servant: models.HolyGrailWarTRPGServant
   }
   CONFIG.Item.documentClass = HolyGrailWarTRPGItem;
   CONFIG.Item.dataModels = {

--- a/template.json
+++ b/template.json
@@ -1,6 +1,6 @@
 {
   "Actor": {
-    "types": ["character", "npc", "master"]
+    "types": ["character", "npc", "master", "servant"]
   },
   "Item": {
     "types": ["item", "feature", "spell"]


### PR DESCRIPTION
Resolves https://github.com/unigiriunini/my-fvtt-system/issues/6

サーヴァント用の Data Model として `HolyGrailWarTRPGServant` を定義する
定義するフィールドは以下の通り

- true_name
  - 真名
  - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型
- wish
  - 願い事
  - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型

これらはテンプレート内で `system.VARIABLE_NAME` として参照可能

なお、マスターや端役と共通のフィールドは https://github.com/unigiriunini/my-fvtt-system/pull/5 で定義する
`wish` はマスターとサーヴァントは持つが端役は持たないため `HolyGrailWarTRPGActorBase` で共通化していない