### PR TITLE
名声用 Data Model を定義

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -27,6 +27,11 @@
       "Item": "HolyGrailWarTRPG Item Sheet"
     },
     "Item": {
+      "Fame": {
+        "Level": "Level",
+        "InsightDifficulty": "Insight Difficulty",
+        "BattlefieldPlacementPoint": "Battlefield Placement Point"
+      },
       "Spell": {
         "SpellLVL": "Level {level} Spells",
         "AddLVL": "Add LVL {level}"
@@ -56,6 +61,7 @@
       "servant": "Servant"
     },
     "Item": {
+      "fame": "Fame",
       "item": "Item",
       "feature": "Feature",
       "spell": "Spell"

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -20,6 +20,13 @@
           "BasicData": "基本データ"
         }
       }
+    },
+    "Item": {
+      "Fame": {
+        "Level": "家名",
+        "InsightDifficulty": "看破目標値",
+        "BattlefieldPlacementPoint": "戦場配置点"
+      }
     }
   },
 
@@ -29,6 +36,9 @@
       "npc": "NPC",
       "master": "マスター",
       "servant": "サーヴァント"
+    },
+    "Item": {
+      "fame": "家名"
     }
   }
 }

--- a/module/data/_module.mjs
+++ b/module/data/_module.mjs
@@ -10,3 +10,4 @@ export {default as HolyGrailWarTRPGItemBase} from "./base-item.mjs";
 export {default as HolyGrailWarTRPGItem} from "./item-item.mjs";
 export {default as HolyGrailWarTRPGFeature} from "./item-feature.mjs";
 export {default as HolyGrailWarTRPGSpell} from "./item-spell.mjs";
+export {default as HolyGrailWarTRPGFame } from "./item-fame.mjs";

--- a/module/data/base-item.mjs
+++ b/module/data/base-item.mjs
@@ -6,8 +6,6 @@ export default class HolyGrailWarTRPGItemBase extends HolyGrailWarTRPGDataModel 
     const fields = foundry.data.fields;
     const schema = {};
 
-    schema.description = new fields.StringField({ required: true, blank: true });
-
     return schema;
   }
 

--- a/module/data/item-fame.mjs
+++ b/module/data/item-fame.mjs
@@ -1,0 +1,16 @@
+import HolyGrailWarTRPGItemBase from "./base-item.mjs";
+
+export default class HolyGrailWarTRPGFame extends HolyGrailWarTRPGItemBase {
+
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    const schema = super.defineSchema();
+
+    schema.level = new fields.StringField({ required: true, blank: true });
+    schema.insight_difficulty = new fields.NumberField({ required: true, nullable: false, initial: 0 });
+    schema.battlefield_placement_point = new fields.NumberField({ required: true, nullable: false, initial: 0 });
+
+    return schema;
+  }
+
+}

--- a/template.json
+++ b/template.json
@@ -3,6 +3,6 @@
     "types": ["character", "npc", "master", "servant"]
   },
   "Item": {
-    "types": ["item", "feature", "spell"]
+    "types": ["item", "feature", "spell", "fame"]
   }
 }


### PR DESCRIPTION
Related to #8 

名声用の Data Model `HolyGrailWarTRPGFame` を定義する
定義するフィールドは以下の通り

- level
  - 家名 (A~E)
  - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型
- insight_difficulty
  - 看破目標値
  - [NumberField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.NumberField.html) 型
- battlefield_placement_point
  - 戦場配置点
  - [NumberField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.NumberField.html) 型

看破目標値と戦場配置点は通常であれば上限と下限を指定可能だが、宝具により異常値が発生する可能性を考慮し指定していない