### PR TITLE
ルーツ用 Data Model を定義

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -32,6 +32,13 @@
         "InsightDifficulty": "Insight Difficulty",
         "BattlefieldPlacementPoint": "Battlefield Placement Point"
       },
+      "Roots": {
+        "Name": "Roots Name",
+        "Trait": {
+          "Name": "Roots Trait Name",
+          "Description": "Roots Trait Description"
+        }
+      },
       "Spell": {
         "SpellLVL": "Level {level} Spells",
         "AddLVL": "Add LVL {level}"
@@ -62,6 +69,7 @@
     },
     "Item": {
       "fame": "Fame",
+      "roots": "Roots",
       "item": "Item",
       "feature": "Feature",
       "spell": "Spell"

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -26,6 +26,13 @@
         "Level": "家名",
         "InsightDifficulty": "看破目標値",
         "BattlefieldPlacementPoint": "戦場配置点"
+      },
+      "Roots": {
+        "Name": "ルーツ名",
+        "Trait": {
+          "Name": "ルーツ特性名",
+          "Description": "ルーツ特性効果"
+        }
       }
     }
   },
@@ -38,7 +45,8 @@
       "servant": "サーヴァント"
     },
     "Item": {
-      "fame": "家名"
+      "fame": "家名",
+      "roots": "ルーツ"
     }
   }
 }

--- a/module/data/_module.mjs
+++ b/module/data/_module.mjs
@@ -11,3 +11,4 @@ export {default as HolyGrailWarTRPGItem} from "./item-item.mjs";
 export {default as HolyGrailWarTRPGFeature} from "./item-feature.mjs";
 export {default as HolyGrailWarTRPGSpell} from "./item-spell.mjs";
 export {default as HolyGrailWarTRPGFame } from "./item-fame.mjs";
+export {default as HolyGrailWarTRPGRoots } from "./base-roots.mjs";

--- a/module/data/item-roots.mjs
+++ b/module/data/item-roots.mjs
@@ -1,0 +1,18 @@
+import HolyGrailWarTRPGItemBase from "./base-item.mjs";
+
+export default class HolyGrailWarTRPGRoots extends HolyGrailWarTRPGItemBase {
+
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    const schema = super.defineSchema();
+
+    schema.name = new fields.StringField({ required: true, blank: true });
+    schema.trait = new fields.SchemaField({
+      name: new fields.StringField({ required: true, blank: true }),
+      description: new fields.StringField({ required: true, blank: true })
+    });
+
+    return schema;
+  }
+
+}

--- a/module/holy-grail-war-trpg.mjs
+++ b/module/holy-grail-war-trpg.mjs
@@ -50,6 +50,7 @@ Hooks.once('init', function () {
   CONFIG.Item.documentClass = HolyGrailWarTRPGItem;
   CONFIG.Item.dataModels = {
     fame: models.HolyGrailWarTRPGFame,
+    roots: models.HolyGrailWarTRPGRoots,
     item: models.HolyGrailWarTRPGItem,
     feature: models.HolyGrailWarTRPGFeature,
     spell: models.HolyGrailWarTRPGSpell

--- a/template.json
+++ b/template.json
@@ -3,6 +3,6 @@
     "types": ["character", "npc", "master", "servant"]
   },
   "Item": {
-    "types": ["item", "feature", "spell", "fame"]
+    "types": ["item", "feature", "spell", "fame", "roots"]
   }
 }


### PR DESCRIPTION
Related to #8 

マスターのルーツ用の Data Model `HolyGrailWarTRPGRoots` を定義する
定義するフィールドは以下の通り

- name
  - ルーツ名
  - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型
- trait
  - ルーツ特性
  - [SchemaField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.SchemaField.html) 型
    - name
      - ルーツ特性名
      - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型
    - description
      - ルーツ特性効果
      - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型

ルーツ特性が与える数値的な効果は [Active Effects](https://foundryvtt.com/article/active-effects/) として実装予定のため、ここでは定義しない