### PR TITLE
制約用 Data Model を定義

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -39,6 +39,10 @@
           "Description": "Roots Trait Description"
         }
       },
+      "Constraint": {
+        "Name": "Constraint Name",
+        "Description": "Constraint Description"
+      },
       "Spell": {
         "SpellLVL": "Level {level} Spells",
         "AddLVL": "Add LVL {level}"
@@ -70,6 +74,7 @@
     "Item": {
       "fame": "Fame",
       "roots": "Roots",
+      "constraint": "Constraint",
       "item": "Item",
       "feature": "Feature",
       "spell": "Spell"

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -33,6 +33,10 @@
           "Name": "ルーツ特性名",
           "Description": "ルーツ特性効果"
         }
+      },
+      "Constraint": {
+        "Name": "制約名",
+        "Description": "制約内容"
       }
     }
   },
@@ -46,7 +50,8 @@
     },
     "Item": {
       "fame": "家名",
-      "roots": "ルーツ"
+      "roots": "ルーツ",
+      "constraint": "制約"
     }
   }
 }

--- a/module/data/_module.mjs
+++ b/module/data/_module.mjs
@@ -12,3 +12,4 @@ export {default as HolyGrailWarTRPGFeature} from "./item-feature.mjs";
 export {default as HolyGrailWarTRPGSpell} from "./item-spell.mjs";
 export {default as HolyGrailWarTRPGFame } from "./item-fame.mjs";
 export {default as HolyGrailWarTRPGRoots } from "./base-roots.mjs";
+export {default as HolyGrailWarTRPGConstraint } from "./item-constraint.mjs";

--- a/module/data/item-constraint.mjs
+++ b/module/data/item-constraint.mjs
@@ -1,0 +1,15 @@
+import HolyGrailWarTRPGItemBase from "./base-item.mjs";
+
+export default class HolyGrailWarTRPGConstraint extends HolyGrailWarTRPGItemBase {
+
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    const schema = super.defineSchema();
+
+    schema.name = new fields.StringField({ required: true, blank: true });
+    schema.description = new fields.StringField({ required: true, blank: true });
+
+    return schema;
+  }
+
+}

--- a/module/holy-grail-war-trpg.mjs
+++ b/module/holy-grail-war-trpg.mjs
@@ -51,6 +51,7 @@ Hooks.once('init', function () {
   CONFIG.Item.dataModels = {
     fame: models.HolyGrailWarTRPGFame,
     roots: models.HolyGrailWarTRPGRoots,
+    constraint: models.HolyGrailWarTRPGConstraint,
     item: models.HolyGrailWarTRPGItem,
     feature: models.HolyGrailWarTRPGFeature,
     spell: models.HolyGrailWarTRPGSpell

--- a/template.json
+++ b/template.json
@@ -3,6 +3,6 @@
     "types": ["character", "npc", "master", "servant"]
   },
   "Item": {
-    "types": ["item", "feature", "spell", "fame", "roots"]
+    "types": ["item", "feature", "spell", "fame", "roots", "constraint"]
   }
 }


### PR DESCRIPTION
Related to #8 

マスターの制約用の Data Model `HolyGrailWarTRPGConstraint` を定義する
定義するフィールドは以下の通り

- name
  - 制約名
  - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型
- description
  - 制約内容
  - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型

制約がアクターに与える効果は [Active Effects](https://foundryvtt.com/article/active-effects/) として実装予定のため、ここでは定義しない