### PR TITLE
幻想の聖杯片用 Data Model を定義

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -43,6 +43,10 @@
         "Name": "Constraint Name",
         "Description": "Constraint Description"
       },
+      "HolyGrailFragment": {
+        "Name": "Holy Grail Fragment Name",
+        "Description": "Holy Grail Fragment Description"
+      },
       "Spell": {
         "SpellLVL": "Level {level} Spells",
         "AddLVL": "Add LVL {level}"
@@ -75,6 +79,7 @@
       "fame": "Fame",
       "roots": "Roots",
       "constraint": "Constraint",
+      "holyGrailFragment": "Holy Grail Fragment",
       "item": "Item",
       "feature": "Feature",
       "spell": "Spell"

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -37,6 +37,10 @@
       "Constraint": {
         "Name": "制約名",
         "Description": "制約内容"
+      },
+      "HolyGrailFragment": {
+        "Name": "効果名",
+        "Description": "効果内容"
       }
     }
   },
@@ -51,7 +55,8 @@
     "Item": {
       "fame": "家名",
       "roots": "ルーツ",
-      "constraint": "制約"
+      "constraint": "制約",
+      "holyGrailFragment": "幻想の聖杯片"
     }
   }
 }

--- a/module/data/_module.mjs
+++ b/module/data/_module.mjs
@@ -13,3 +13,4 @@ export {default as HolyGrailWarTRPGSpell} from "./item-spell.mjs";
 export {default as HolyGrailWarTRPGFame } from "./item-fame.mjs";
 export {default as HolyGrailWarTRPGRoots } from "./item-roots.mjs";
 export {default as HolyGrailWarTRPGConstraint } from "./item-constraint.mjs";
+export {default as HolyGrailWarTRPGHolyGrailFragment} from "./item-holy-grail-fragment.mjs";

--- a/module/data/item-holy-grail-fragment.mjs
+++ b/module/data/item-holy-grail-fragment.mjs
@@ -1,0 +1,15 @@
+import HolyGrailWarTRPGItemBase from "./base-item.mjs";
+
+export default class HolyGrailWarTRPGHolyGrailFragment extends HolyGrailWarTRPGItemBase {
+
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    const schema = super.defineSchema();
+
+    schema.name = new fields.StringField({ required: true, blank: true });
+    schema.description = new fields.StringField({ required: true, blank: true });
+
+    return schema;
+  }
+
+}

--- a/module/holy-grail-war-trpg.mjs
+++ b/module/holy-grail-war-trpg.mjs
@@ -52,6 +52,7 @@ Hooks.once('init', function () {
     fame: models.HolyGrailWarTRPGFame,
     roots: models.HolyGrailWarTRPGRoots,
     constraint: models.HolyGrailWarTRPGConstraint,
+    holyGrailFragment: models.HolyGrailWarTRPGHolyGrailFragment,
     item: models.HolyGrailWarTRPGItem,
     feature: models.HolyGrailWarTRPGFeature,
     spell: models.HolyGrailWarTRPGSpell

--- a/template.json
+++ b/template.json
@@ -3,6 +3,6 @@
     "types": ["character", "npc", "master", "servant"]
   },
   "Item": {
-    "types": ["item", "feature", "spell", "fame", "roots", "constraint"]
+    "types": ["item", "feature", "spell", "fame", "roots", "constraint", "holyGrailFragment"]
   }
 }


### PR DESCRIPTION
Related to #8 

幻想の聖杯片用の Data Model `HolyGrailWarTRPGHolyGrailFragment` を定義する
定義するフィールドは以下の通り

- name
  - 効果名
  - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型
- description
  - 効果内容
  - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型

幻想の聖杯片が与える数値的な効果は [Active Effects](https://foundryvtt.com/article/active-effects/) として実装予定のため、ここでは定義しない