### PR TITLE
幻想の聖杯片用 Data Model に消費済みフラグを追加

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -45,7 +45,8 @@
       },
       "HolyGrailFragment": {
         "Name": "Holy Grail Fragment Name",
-        "Description": "Holy Grail Fragment Description"
+        "Description": "Holy Grail Fragment Description",
+        "Consumed": "Consumed"
       },
       "Spell": {
         "SpellLVL": "Level {level} Spells",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -40,7 +40,8 @@
       },
       "HolyGrailFragment": {
         "Name": "効果名",
-        "Description": "効果内容"
+        "Description": "効果内容",
+        "Consumed": "消費済み"
       }
     }
   },

--- a/module/data/item-holy-grail-fragment.mjs
+++ b/module/data/item-holy-grail-fragment.mjs
@@ -8,6 +8,7 @@ export default class HolyGrailWarTRPGHolyGrailFragment extends HolyGrailWarTRPGI
 
     schema.name = new fields.StringField({ required: true, blank: true });
     schema.description = new fields.StringField({ required: true, blank: true });
+    schema.consumed = new fields.BooleanField({ required: true, nullable: false, initial: false });
 
     return schema;
   }


### PR DESCRIPTION
Related to #8 

ルールブックに

> まず、潜在魔術を使用するために消費する幻想の聖杯片の数を決定します。潜在魔術を使用するためには、自身か自身の契約サーヴァントの所有している幻想の聖杯片をコストの個数だけ消費する必要があります。
> 消費された幻想の聖杯片は物自体は手元に残りますが、特別効果も《聖杯片MP回復》時のMP回復効果も失い、以降潜在魔術の使用コストとして使用できなくなります。

とあるため、幻想の聖杯片が消費済みかを管理するフラグが `HolyGrailWarTRPGHolyGrailFragment` に必要
現状は潜在魔術使用時にどの聖杯片を消費するかをPLが決定する必要があるため、ユーザが操作可能なフィールドとして以下を追加する

- consumed
  - 消費済みフラグ
  - 未消費であれば `false`, 消費済みであれば `true`
  - [BooleanField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.BooleanField.html) 型