### PR TITLE
潜在魔術用 Data Model を定義

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -48,6 +48,19 @@
         "Description": "Holy Grail Fragment Description",
         "Consumed": "Consumed"
       },
+      "LatentMagecraft": {
+        "ConsumedHolyGrailFragment": "Consumed Holy Grail Fragment",
+        "LatentMagecraftPoint": "Latent Magecraft Point",
+        "Type": "Type",
+        "TriggeringTiming": {
+          "Description": "Triggering Timing Description",
+          "ConsumedLatentMagecraftPoint": "Triggering Timing's Consumed Latent Magecraft Point"
+        },
+        "Effect": {
+          "Description": "Effect Description",
+          "ConsumedLatentMagecraftPoint": "Effect's Consumed Latent Magecraft Point"
+        }
+      },
       "Spell": {
         "SpellLVL": "Level {level} Spells",
         "AddLVL": "Add LVL {level}"
@@ -81,6 +94,7 @@
       "roots": "Roots",
       "constraint": "Constraint",
       "holyGrailFragment": "Holy Grail Fragment",
+      "latentMagecraft": "Latent Magecraft",
       "item": "Item",
       "feature": "Feature",
       "spell": "Spell"

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -42,6 +42,19 @@
         "Name": "効果名",
         "Description": "効果内容",
         "Consumed": "消費済み"
+      },
+      "LatentMagecraft": {
+        "ConsumedHolyGrailFragment": "消費聖杯片個数",
+        "LatentMagecraftPoint": "潜在魔術作成点",
+        "Type": "タイプ",
+        "TriggeringTiming": {
+          "Description": "発動タイミング内容",
+          "ConsumedLatentMagecraftPoint": "消費作成点"
+        },
+        "Effect": {
+          "Description": "効果内容",
+          "ConsumedLatentMagecraftPoint": "消費作成点"
+        }
       }
     }
   },
@@ -57,7 +70,8 @@
       "fame": "家名",
       "roots": "ルーツ",
       "constraint": "制約",
-      "holyGrailFragment": "幻想の聖杯片"
+      "holyGrailFragment": "幻想の聖杯片",
+      "latentMagecraft": "潜在魔術"
     }
   }
 }

--- a/module/data/_module.mjs
+++ b/module/data/_module.mjs
@@ -14,3 +14,4 @@ export {default as HolyGrailWarTRPGFame } from "./item-fame.mjs";
 export {default as HolyGrailWarTRPGRoots } from "./item-roots.mjs";
 export {default as HolyGrailWarTRPGConstraint } from "./item-constraint.mjs";
 export {default as HolyGrailWarTRPGHolyGrailFragment} from "./item-holy-grail-fragment.mjs";
+export {default as HolyGrailWarTRPGLatentMagecraft} from "./item-latent-magecraft.mjs";

--- a/module/data/item-latent-magecraft.mjs
+++ b/module/data/item-latent-magecraft.mjs
@@ -1,0 +1,25 @@
+import HolyGrailWarTRPGItemBase from "./base-item.mjs";
+
+export default class HolyGrailWarTRPGLatentMagecraft extends HolyGrailWarTRPGItemBase {
+
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    const schema = super.defineSchema();
+
+    schema.consumed_holy_grail_fragment = new fields.NumberField({ required: true, nullable: false, initial: 0 });
+    schema.latent_magecraft_point = new fields.NumberField({ required: true, nullable: false, initial: 0 });
+    schema.type = new fields.StringField({ required: true, blank: true });
+
+    schema.triggering_timing = new fields.SchemaField({
+      description: new fields.StringField({ required: true, blank: true }),
+      consumed_latent_magecraft_point = new fields.NumberField({ required: true, nullable: false, initial: 0 })
+    });
+
+    schema.effect = new fields.SchemaField({
+      description: new fields.StringField({ required: true, blank: true }),
+      consumed_latent_magecraft_point = new fields.NumberField({ required: true, nullable: false, initial: 0 })
+    });
+
+    return schema;
+  }
+}

--- a/module/holy-grail-war-trpg.mjs
+++ b/module/holy-grail-war-trpg.mjs
@@ -53,6 +53,7 @@ Hooks.once('init', function () {
     roots: models.HolyGrailWarTRPGRoots,
     constraint: models.HolyGrailWarTRPGConstraint,
     holyGrailFragment: models.HolyGrailWarTRPGHolyGrailFragment,
+    latentMagecraft: models.HolyGrailWarTRPGLatentMagecraft,
     item: models.HolyGrailWarTRPGItem,
     feature: models.HolyGrailWarTRPGFeature,
     spell: models.HolyGrailWarTRPGSpell

--- a/template.json
+++ b/template.json
@@ -3,6 +3,6 @@
     "types": ["character", "npc", "master", "servant"]
   },
   "Item": {
-    "types": ["item", "feature", "spell", "fame", "roots", "constraint", "holyGrailFragment"]
+    "types": ["item", "feature", "spell", "fame", "roots", "constraint", "holyGrailFragment", "latentMagecraft"]
   }
 }


### PR DESCRIPTION
Related to https://github.com/unigiriunini/holy-grail-war-trpg/issues/8

幻想の聖杯片用の Data Model `HolyGrailWarTRPGLatentMagecraft` を定義する
定義するフィールドは以下の通り

- consumed_holy_grail_fragment
    -  消費聖杯片個数
    - [NumberField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.NumberField.html) 型
- latent_magecraft_point
    - 潜在魔術作成点
    - [NumberField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.NumberField.html) 型
- type
    - タイプ
    - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型
- triggering_timing
    - 発動タイミング
    - [SchemaField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.SchemaField.html) 型
        - description
            - 発動タイミング内容
            - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型
        - consumed_latent_magecraft_point
            - 消費作成点
            - [NumberField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.NumberField.html) 型
- effect
    - 効果
    - [SchemaField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.SchemaField.html) 型
        - description
            - 効果内容
            - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型
        - consumed_latent_magecraft_point
            - 消費作成点
            - [NumberField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.NumberField.html) 型

潜在魔術が与える数値的な効果は [Active Effects](https://foundryvtt.com/article/active-effects/) として実装予定のため、ここでは定義しない