### PR TITLE
サーヴァントクラス用 Data Model を定義

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -61,6 +61,21 @@
           "ConsumedLatentMagecraftPoint": "Effect's Consumed Latent Magecraft Point"
         }
       },
+      "ServantClass": {
+        "Name": "Servant Class Name",
+        "Trait ": {
+          "Name": "Trait Name",
+          "Description": "Trait Description"
+        },
+        "LowerLimitStatus": {
+          "Strength": "Strength's Lower Limit",
+          "Constitution": "Constitution's Lower Limit",
+          "Dexterity": "Dexterity's Lower Limit",
+          "Mana": "Mana's Lower Limit",
+          "Luck": "Luck's Lower Limit",
+          "NoblePhantasm": "Noble Phantasm's Lower Limit"
+        }
+      },
       "Spell": {
         "SpellLVL": "Level {level} Spells",
         "AddLVL": "Add LVL {level}"
@@ -95,6 +110,7 @@
       "constraint": "Constraint",
       "holyGrailFragment": "Holy Grail Fragment",
       "latentMagecraft": "Latent Magecraft",
+      "servantClass": "Servant Class",
       "item": "Item",
       "feature": "Feature",
       "spell": "Spell"

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -55,6 +55,21 @@
           "Description": "効果内容",
           "ConsumedLatentMagecraftPoint": "消費作成点"
         }
+      },
+      "ServantClass": {
+        "Name": "クラス名",
+        "Trait ": {
+          "Name": "クラス特性名",
+          "Description": "クラス特性効果説明文"
+        },
+        "LowerLimitStatus": {
+          "Strength": "筋力下限",
+          "Constitution": "耐久下限",
+          "Dexterity": "敏捷下限",
+          "Mana": "魔力下限",
+          "Luck": "幸運下限",
+          "NoblePhantasm": "宝具下限"
+        }
       }
     }
   },
@@ -71,7 +86,8 @@
       "roots": "ルーツ",
       "constraint": "制約",
       "holyGrailFragment": "幻想の聖杯片",
-      "latentMagecraft": "潜在魔術"
+      "latentMagecraft": "潜在魔術",
+      "servantClass": "クラス"
     }
   }
 }

--- a/module/data/_module.mjs
+++ b/module/data/_module.mjs
@@ -15,3 +15,4 @@ export {default as HolyGrailWarTRPGRoots } from "./item-roots.mjs";
 export {default as HolyGrailWarTRPGConstraint } from "./item-constraint.mjs";
 export {default as HolyGrailWarTRPGHolyGrailFragment} from "./item-holy-grail-fragment.mjs";
 export {default as HolyGrailWarTRPGLatentMagecraft} from "./item-latent-magecraft.mjs";
+export {default as HolyGrailWarTRPGServantClass} from "./item-servant-class.mjs";

--- a/module/data/item-servant-class.mjs
+++ b/module/data/item-servant-class.mjs
@@ -1,0 +1,27 @@
+import HolyGrailWarTRPGItemBase from "./base-item.mjs";
+
+export default class HolyGrailWarTRPGServantClass extends HolyGrailWarTRPGItemBase {
+
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    const schema = super.defineSchema();
+
+    schema.name = new fields.StringField({ required: true, blank: true });
+
+    schema.trait = new fields.SchemaField({
+      name: new fields.StringField({ required: true, blank: true }),
+      description: new fields.StringField({ required: true, blank: true })
+    });
+
+    schema.lower_limit_status = new fields.SchemaField({
+      strength: new fields.StringField({ required: true, blank: true }),
+      constitution: new fields.StringField({ required: true, blank: true }),
+      dexterity: new fields.StringField({ required: true, blank: true }),
+      mana: new fields.StringField({ required: true, blank: true }),
+      luck: new fields.StringField({ required: true, blank: true }),
+      noble_phantasm: new fields.StringField({ required: true, blank: true })
+    });
+
+    return schema;
+  }
+}

--- a/module/holy-grail-war-trpg.mjs
+++ b/module/holy-grail-war-trpg.mjs
@@ -54,6 +54,7 @@ Hooks.once('init', function () {
     constraint: models.HolyGrailWarTRPGConstraint,
     holyGrailFragment: models.HolyGrailWarTRPGHolyGrailFragment,
     latentMagecraft: models.HolyGrailWarTRPGLatentMagecraft,
+    servantClass: models.HolyGrailWarTRPGServantClass,
     item: models.HolyGrailWarTRPGItem,
     feature: models.HolyGrailWarTRPGFeature,
     spell: models.HolyGrailWarTRPGSpell

--- a/template.json
+++ b/template.json
@@ -3,6 +3,16 @@
     "types": ["character", "npc", "master", "servant"]
   },
   "Item": {
-    "types": ["item", "feature", "spell", "fame", "roots", "constraint", "holyGrailFragment", "latentMagecraft"]
+    "types": [
+      "item",
+      "feature",
+      "spell",
+      "fame",
+      "roots",
+      "constraint",
+      "holyGrailFragment",
+      "latentMagecraft",
+      "servantClass"
+    ]
   }
 }


### PR DESCRIPTION
Related to https://github.com/unigiriunini/holy-grail-war-trpg/issues/8

サーヴァントのクラス用の Data Model `HolyGrailWarTRPGServantClass` を定義する
定義するフィールドは以下の通り

- name
    - クラス名
    - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型
- trait
    - クラス特性
    - [SchemaField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.SchemaField.html) 型
        - name
            - クラス特性名
            - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型
        - description
            - クラス特性効果説明文
            - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型
- lower_limit_status
    - ステータス下限
    - [SchemaField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.SchemaField.html) 型
        - strength
            - 筋力
            - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型
        - constitution
            - 耐久
            - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型
        - dexterity
            - 敏捷
            - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型
        - mana
            - 魔力
            - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型
        - luck
            - 幸運
            - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型
        - noble_phantasm
            - 宝具
            - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型