### PR TITLE
被特攻属性用 Data Model を定義

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -76,6 +76,10 @@
           "NoblePhantasm": "Noble Phantasm's Lower Limit"
         }
       },
+      "Weakness": {
+        "Name": "Weakness Name",
+        "Description": "Weakness Description"
+      },
       "Spell": {
         "SpellLVL": "Level {level} Spells",
         "AddLVL": "Add LVL {level}"
@@ -111,6 +115,7 @@
       "holyGrailFragment": "Holy Grail Fragment",
       "latentMagecraft": "Latent Magecraft",
       "servantClass": "Servant Class",
+      "weakness": "Weakness",
       "item": "Item",
       "feature": "Feature",
       "spell": "Spell"

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -70,6 +70,10 @@
           "Luck": "幸運下限",
           "NoblePhantasm": "宝具下限"
         }
+      },
+      "Weakness": {
+        "Name": "被特攻属性名",
+        "Description": "被特攻属性説明文"
       }
     }
   },
@@ -87,7 +91,8 @@
       "constraint": "制約",
       "holyGrailFragment": "幻想の聖杯片",
       "latentMagecraft": "潜在魔術",
-      "servantClass": "クラス"
+      "servantClass": "クラス",
+      "weakness": "被特攻属性",
     }
   }
 }

--- a/module/data/_module.mjs
+++ b/module/data/_module.mjs
@@ -16,3 +16,4 @@ export {default as HolyGrailWarTRPGConstraint } from "./item-constraint.mjs";
 export {default as HolyGrailWarTRPGHolyGrailFragment} from "./item-holy-grail-fragment.mjs";
 export {default as HolyGrailWarTRPGLatentMagecraft} from "./item-latent-magecraft.mjs";
 export {default as HolyGrailWarTRPGServantClass} from "./item-servant-class.mjs";
+export {default as HolyGrailWarTRPGWeakness} from "./item-weakness.mjs";

--- a/module/data/item-weakness.mjs
+++ b/module/data/item-weakness.mjs
@@ -1,0 +1,15 @@
+import HolyGrailWarTRPGItemBase from "./base-item.mjs";
+
+export default class HolyGrailWarTRPGWeakness extends HolyGrailWarTRPGItemBase {
+
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    const schema = super.defineSchema();
+
+    schema.name = new fields.StringField({ required: true, blank: true });
+    schema.description = new fields.StringField({ required: true, blank: true });
+
+    return schema;
+  }
+
+}

--- a/module/holy-grail-war-trpg.mjs
+++ b/module/holy-grail-war-trpg.mjs
@@ -55,6 +55,7 @@ Hooks.once('init', function () {
     holyGrailFragment: models.HolyGrailWarTRPGHolyGrailFragment,
     latentMagecraft: models.HolyGrailWarTRPGLatentMagecraft,
     servantClass: models.HolyGrailWarTRPGServantClass,
+    weakness: models.HolyGrailWarTRPGWeakness,
     item: models.HolyGrailWarTRPGItem,
     feature: models.HolyGrailWarTRPGFeature,
     spell: models.HolyGrailWarTRPGSpell

--- a/template.json
+++ b/template.json
@@ -12,7 +12,8 @@
       "constraint",
       "holyGrailFragment",
       "latentMagecraft",
-      "servantClass"
+      "servantClass",
+      "weakness"
     ]
   }
 }


### PR DESCRIPTION
Related to https://github.com/unigiriunini/holy-grail-war-trpg/issues/8

被特攻属性用の Data Model `HolyGrailWarTRPGWeakness` を定義する
定義するフィールドは以下の通り

- name
    - 被特攻属性名
    - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型
- description
    - 被特攻属性説明文
    - [StringField](https://foundryvtt.com/api/v11/classes/foundry.data.fields.StringField.html) 型